### PR TITLE
Clean broken address data

### DIFF
--- a/src/Crawler/EventInfoCrawler.php
+++ b/src/Crawler/EventInfoCrawler.php
@@ -68,10 +68,17 @@ final class EventInfoCrawler extends AbstractCrawler implements EventInfoCrawler
         $venueNode   = $node->filter('.event-detail');
         $addressNode = $venueNode->filter('.event-detail-address');
 
-        $adress = new VenueAddress(
+        $cityName   = $this->parseString($addressNode->filter('[itemprop="addressLocality"]'));
+        $postalCode = $this->parseString($addressNode->filter('[itemprop="postalCode"]'));
+
+        if (null !== $postalCode && null !== $cityName && \strlen($postalCode) > 3) {
+            $cityName = trim(str_replace($postalCode, '', $cityName));
+        }
+
+        $adress     = new VenueAddress(
             $this->parseString($addressNode->filter('[itemprop="streetAddress"]')),
-            $this->parseString($addressNode->filter('[itemprop="postalCode"]')),
-            $this->parseString($addressNode->filter('[itemprop="addressLocality"]')),
+            $postalCode,
+            $cityName,
             $this->parseString($addressNode->filter('[itemprop="addressCountry"]'))
         );
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Remove zip code information from city name.

There are some events on Last.fm that contain invalid address data, e.g. the zip code is entered as a city name (https://www.last.fm/festival/4548967+Under+the+Black+Sun).