### PR TITLE
Add forTrack method to TrackInfoBuilder

### DIFF
--- a/src/Builder/TrackInfoBuilder.php
+++ b/src/Builder/TrackInfoBuilder.php
@@ -50,6 +50,16 @@ final class TrackInfoBuilder
     /**
      * @return TrackInfoBuilder
      */
+    public function forTrack(string $track): self
+    {
+        $this->query['track'] = $track;
+
+        return $this;
+    }
+
+    /**
+     * @return TrackInfoBuilder
+     */
     public function forUsername(string $name): self
     {
         $this->query['username'] = $name;

--- a/tests/Builder/TrackInfoBuilderTest.php
+++ b/tests/Builder/TrackInfoBuilderTest.php
@@ -43,7 +43,7 @@ final class TrackInfoBuilderTest extends TestCase
 
         $expected = [
             'artist' => 'Slipknot',
-            'track'  => 'Duality'
+            'track'  => 'Duality',
         ];
 
         static::assertSame($expected, $builder->getQuery());

--- a/tests/Builder/TrackInfoBuilderTest.php
+++ b/tests/Builder/TrackInfoBuilderTest.php
@@ -36,6 +36,19 @@ final class TrackInfoBuilderTest extends TestCase
         static::assertSame($expected, $builder->getQuery());
     }
 
+    public function testForTrack(): void
+    {
+        $builder = TrackInfoBuilder::forArtist('Slipknot');
+        $builder->forTrack('Duality');
+
+        $expected = [
+            'artist' => 'Slipknot',
+            'track'  => 'Duality'
+        ];
+
+        static::assertSame($expected, $builder->getQuery());
+    }
+
     public function testForUsername(): void
     {
         $builder = TrackInfoBuilder::forMbid('a466c2a2-6517-42fb-a160-1087c3bafd9f')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Add forTrack method to TrackInfoBuilder

This allows the query to specify a track, as well as an artist when querying for track info.

Proposing adding this due to limitations when trying to call "getInfo" method in the TrackService object, as if the "mbid" param is invalid, then there isn't any way to query for a track's info, as "artist" and "track" params are both required.
